### PR TITLE
fix: handle throw error on LlmInference return with try

### DIFF
--- a/ios/LlmInferenceModel.swift
+++ b/ios/LlmInferenceModel.swift
@@ -32,7 +32,7 @@ final class LlmInferenceModel {
     llmOptions.topk = self.topK
     llmOptions.temperature = self.temperature
     llmOptions.randomSeed = self.randomSeed
-    return LlmInference(options: llmOptions)
+    return try? LlmInference(options: llmOptions)
   }()
 
   var handle: Int


### PR DESCRIPTION
This hotfix handles a error preventing compilation of module.

Error message:
Call can throw, but it is not marked with 'try' and the error is not handled.