### PR TITLE
Fix for Android OpenCL and added a couple of improvements

### DIFF
--- a/example/android/app/src/debug/AndroidManifest.xml
+++ b/example/android/app/src/debug/AndroidManifest.xml
@@ -4,6 +4,6 @@
 
     <application
         android:usesCleartextTraffic="true"
-        tools:targetApi="28"
+        tools:targetApi="31"
         tools:ignore="GoogleAppIndexingWarning"/>
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -21,5 +21,11 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+      <!-- Required to initialize the LlmInference -->
+      <uses-native-library
+          android:name="libOpenCL.so"
+          android:required="false"/>
+      <uses-native-library android:name="libOpenCL-car.so" android:required="false"/>
+      <uses-native-library android:name="libOpenCL-pixel.so" android:required="false"/>
     </application>
 </manifest>

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,8 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "build:android": "cd android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
+    "build:clean": "cd android && ./gradlew clean",
+    "build:android": "cd android && ./gradlew clean && ./gradlew assembleRelease --no-daemon --console=plain  -PreactNativeArchitectures=arm64-v8a",
     "build:ios": "cd ios && xcodebuild -workspace LlmMediapipeExample.xcworkspace -scheme LlmMediapipeExample -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO"
   },
   "dependencies": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -48,6 +48,8 @@ function App(): React.JSX.Element {
   const llmInference = useLlmInference({
     storageType: 'asset',
     modelName: 'gemma-2b-it-cpu-int4.bin',
+    // 'gemma-1.1-2b-it-gpu-int4.bin' or the name of the model that
+    // you placed at android/app/src/main/assets/{MODEL_FILE}
   });
 
   const onSendPrompt = React.useCallback(async () => {


### PR DESCRIPTION
This PR is meant to fix the problem exposed in this issue #7(Cannot read property 'createModel' of null)  and introduces a bump on the targetApi for the manifest file (copied from the [MediaPipe repo](https://github.com/google-ai-edge/mediapipe-samples/tree/main/examples/llm_inference) from Google)

It also adds some explanations on where to put the model files and adds the command for both cleaning and creating release APKs without the risk of keeping cached bugs from previous iterations.

I tested the results on my Oneplus Nord as well as emulated pixels and seems very legit.
Hope it helps!